### PR TITLE
JST-DEV: Adding BV scope for internal publish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bunyan-sentry-stream",
+  "name": "@bv/bunyan-sentry-stream",
   "version": "1.0.2",
   "description": "Write log to Sentry/Raven by using Bunyan",
   "keywords": [


### PR DESCRIPTION
## Problem
In order to be able to publish this as a package for internal consumption, we'll need to add this scope tag.

## Solution

Added the scope tag to the package name

## Verification

Check that this change appears accurate with the instructions here: https://docs.npmjs.com/getting-started/scoped-packages

## Note

Is there any chance we could just consolidate back to using the original fork? Or move this to a BV repo instead of Taylor's personal account?